### PR TITLE
Proposal: Add ability to quickly run starter project on Val Town

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ Currently, the Cerebras API provides access to two models: Meta’s Llama 3.1 8B
 - [Play with our live chatbot demo](https://inference.cerebras.ai/)
 - [Experiment with our inference solution in the playground](https://cloud.cerebras.ai/)
 - [Explore our API reference documentation](https://inference-docs.cerebras.ai/api-reference/chat-completions)
-- [![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/stevekrouse/cerebrasTemplate)
 
 ## 📁 Projects Overview
 
 This repository contains multiple example projects, each demonstrating different capabilities of the Cerebras Inference API. Each project is located in its own folder and contains a detailed README.
+
+[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/stevekrouse/cerebrasTemplate)
 
 ### 🔗 Example Projects
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Currently, the Cerebras API provides access to two models: Meta’s Llama 3.1 8B
 - [Play with our live chatbot demo](https://inference.cerebras.ai/)
 - [Experiment with our inference solution in the playground](https://cloud.cerebras.ai/)
 - [Explore our API reference documentation](https://inference-docs.cerebras.ai/api-reference/chat-completions)
+- [![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/stevekrouse/cerebrasTemplate)
 
 ## 📁 Projects Overview
 


### PR DESCRIPTION
Hey there! 

We’d love to add a [Val Town](https://www.val.town/) badge to the README so new users can spin up a working Cerebras Inference API demo instantly.

## Why this could be helpful:
1.  Gives users instant access to a working example of the Cerebras API.
2.  Lets them fork and customize the example in a single click.
3.  Helps avoid local development headaches (like node/npm issues) so users can focus on your API instead. 
4.  Overlapping interest between Val Town and Cerebras: 500+ forks on [CerebrasCoder’s Val Town template](https://www.val.town/v/stevekrouse/cerebras_coder) and 100K+ projects built, after our [most recent hackathon collab with Cerebras](https://lu.ma/blxlfi33)!

## Proposed badge in README:
[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/stevekrouse/cerebrasTemplate)

## In action:
![Clipboard-20250204-195024-653](https://github.com/user-attachments/assets/01d4e453-e78e-449e-bf81-5b1455afd459)

I work at Val Town and we'd be stoked to be able to have a place in Cerebras' docs or open-source repos. We’re totally open to any tweaks you’d like us to make! 

We’re happy to help maintain this starter on Val Town as your API evolves, or transfer ownership if you'd prefer full control.

The PR is ready to go, but we’d love to hear your thoughts! :)